### PR TITLE
chore: add Dependabot + agent workflow (PS-4701)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "16:45"
+      timezone: "America/Vancouver"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,12 @@ updates:
       time: "16:45"
       timezone: "America/Vancouver"
     open-pull-requests-limit: 5
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "16:50"
+      timezone: "America/Vancouver"
+    open-pull-requests-limit: 5

--- a/.github/workflows/dependabot-agent.yml
+++ b/.github/workflows/dependabot-agent.yml
@@ -1,0 +1,19 @@
+name: Dependabot Agent
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+# contents: read is sufficient since Dependabot only manages github-actions
+# updates here — no lockfile or format remediation push-back needed.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependabot:
+    uses: unbounce/agentic-tools/.github/workflows/dependabot-agent-shared.yml@main
+    with:
+      ecosystem: none
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/dependabot-agent.yml
+++ b/.github/workflows/dependabot-agent.yml
@@ -12,6 +12,9 @@ permissions:
 
 jobs:
   dependabot:
+    if: |
+      (github.actor == 'dependabot[bot]' || github.actor == 'app/dependabot') &&
+      startsWith(github.event.pull_request.head.ref, 'dependabot/')
     uses: unbounce/agentic-tools/.github/workflows/dependabot-agent-shared.yml@main
     with:
       ecosystem: none

--- a/.github/workflows/dependabot-agent.yml
+++ b/.github/workflows/dependabot-agent.yml
@@ -20,3 +20,4 @@ jobs:
       ecosystem: none
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/dependabot-agent.yml
+++ b/.github/workflows/dependabot-agent.yml
@@ -15,7 +15,7 @@ jobs:
     if: |
       (github.actor == 'dependabot[bot]' || github.actor == 'app/dependabot') &&
       startsWith(github.event.pull_request.head.ref, 'dependabot/')
-    uses: unbounce/agentic-tools/.github/workflows/dependabot-agent-shared.yml@main
+    uses: unbounce/agentic-tools/.github/workflows/dependabot-agent-shared.yml@v1
     with:
       ecosystem: none
     secrets:


### PR DESCRIPTION
## Summary
Onboards this repo to the PS Dependabot rollout. Adds weekly Dependabot scheduling and a thin agent caller via the shared workflow in `agentic-tools`.

## Changes
- `.github/dependabot.yml` — github-actions, weekly Thursday 16:45
- `.github/workflows/dependabot-agent.yml` — thin caller (`ecosystem: none`)

## Jira
[PS-4701](https://unbounce.atlassian.net/browse/PS-4701)

[PS-4701]: https://unbounce.atlassian.net/browse/PS-4701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ